### PR TITLE
fix(headers): lowercase entries to avoid repetition

### DIFF
--- a/library/src/main/java/com/lagradost/nicehttp/Utils.kt
+++ b/library/src/main/java/com/lagradost/nicehttp/Utils.kt
@@ -107,7 +107,8 @@ fun getHeaders(
             "Cookie" to cookie.entries.joinToString(" ") {
                 "${it.key}=${it.value};"
             }) else mapOf()
-    val tempHeaders = (headers + cookieMap + refererMap)
+    // Handle case-insensitive header names by keeping only the last occurrence in lowercase
+    val tempHeaders = (headers + cookieMap + refererMap).mapKeys { it.key.lowercase() }
     return tempHeaders.toHeaders()
 }
 


### PR DESCRIPTION
HTTP header names are case-insensitive (RFC 2616, RFC 7230). Therefore, "User-Agent" and "user-agent", for example, should be treated as the same key.

By mapping all keys to lowercase, only the last occurrence remains.

See also https://github.com/square/okhttp/issues/9238

Closes https://github.com/recloudstream/cloudstream/issues/2343